### PR TITLE
Use pip installed charmcraft for CI

### DIFF
--- a/script/build
+++ b/script/build
@@ -10,7 +10,16 @@ CHARM_SRC="$(realpath "charms/$CHARM")"
 CHARM_DST="$CHARM_BUILD_DIR/$CHARM.charm"
 CHARM_DST_UNZIP="$CHARM_BUILD_DIR/$CHARM"
 
-(cd "$CHARM_BUILD_DIR" && charmcraft build -f "$CHARM_SRC" 2>&1) | sed -e "s,in '.*,in '$CHARM_DST',"
+if [[ -x $HOME/.local/bin/charmcraft ]]; then
+    # Use pip version of charmcraft if available due to
+    # issue with non-standard HOME causing problems in CI:
+    # https://forum.snapcraft.io/t/support-for-non-home-homedirs/11209
+    CHARMCRAFT="$HOME/.local/bin/charmcraft"
+else
+    CHARMCRAFT="charmcraft"
+fi
+
+(cd "$CHARM_BUILD_DIR" && "$CHARMCRAFT" build -f "$CHARM_SRC" 2>&1) | sed -e "s,in '.*,in '$CHARM_DST',"
 
 # also provide unzipped version for `charm push`
 rm -rf "$CHARM_DST_UNZIP"


### PR DESCRIPTION
The CI system uses a HOME directory outside of /home which currently isn't supported by snapd so is failing. This works around it by preferring the pip installed version that CI has.