### PR TITLE
Use venv for charmcraft pip install, if active

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -33,9 +33,16 @@ if [[ "$HOME" != "/home/"* ]]; then
         echo "Installing python3-pip..."
         sudo apt install -qyf python3-pip
     fi
-    pip3 install --user charmcraft
+    if [[ -z "$VIRTUAL_ENV" ]]; then
+        echo "Installing charmcraft as user package..."
+        pip3 install --user charmcraft
+    else
+        echo "Installing charmcraft into venv..."
+        # Can just install directly into the active venv
+        pip3 install charmcraft
+    fi
 elif ! which charmcraft > /dev/null; then
-    echo "Installing charmcraft..."
+    echo "Installing charmcraft snap..."
     $snap_sudo snap install charmcraft --beta
 fi
 if ! which yq > /dev/null; then

--- a/script/build
+++ b/script/build
@@ -10,13 +10,18 @@ CHARM_SRC="$(realpath "charms/$CHARM")"
 CHARM_DST="$CHARM_BUILD_DIR/$CHARM.charm"
 CHARM_DST_UNZIP="$CHARM_BUILD_DIR/$CHARM"
 
-if [[ -x $HOME/.local/bin/charmcraft ]]; then
-    # Use pip version of charmcraft if available due to
-    # issue with non-standard HOME causing problems in CI:
-    # https://forum.snapcraft.io/t/support-for-non-home-homedirs/11209
+# Use pip version of charmcraft if available due to
+# issue with non-standard HOME causing problems in CI:
+# https://forum.snapcraft.io/t/support-for-non-home-homedirs/11209
+if [[ -x "$VIRTUAL_ENV/bin/charmcraft" ]]; then
+    # Use charmcraft from the active venv
+    CHARMCRAFT="$VIRTUAL_ENV/bin/charmcraft"
+elif [[ -x $HOME/.local/bin/charmcraft ]]; then
+    # Use charmcraft from user pacakage
     CHARMCRAFT="$HOME/.local/bin/charmcraft"
 else
-    CHARMCRAFT="charmcraft"
+    # Use charmcraft snap
+    CHARMCRAFT="/snap/bin/charmcraft"
 fi
 
 (cd "$CHARM_BUILD_DIR" && "$CHARMCRAFT" build -f "$CHARM_SRC" 2>&1) | sed -e "s,in '.*,in '$CHARM_DST',"


### PR DESCRIPTION
The CI environment has a venv activated which prevents the user package approach in #8 from working, so detect and handle that.