### PR TITLE
Remove forcing /snap/bin to front of PATH

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
 
-export PATH="/snap/bin:$PATH"
-
 if [[ "$(snap whoami)" == "email: -" ]]; then
     snap="sudo snap"
 else

--- a/script/build
+++ b/script/build
@@ -1,8 +1,5 @@
 #!/bin/bash
-
-set -e
-
-export PATH=/snap/bin:$PATH
+set -eu
 
 mkdir -p "$CHARM_BUILD_DIR"
 

--- a/script/upload
+++ b/script/upload
@@ -1,8 +1,5 @@
 #!/bin/bash
-
-set -e
-
-export PATH=/snap/bin:$PATH
+set -eu
 
 if ! charm whoami > /dev/null; then
     echo "Not logged into charm store" 2>&1


### PR DESCRIPTION
CI needs to use the pip package of charmcraft due to the use of a non-standard HOME dir, and if a dev is using the snap then they should already have it on the PATH.