### PR TITLE
Fix issues: rbac permissions and ARP on the network

### DIFF
--- a/charms/metallb-speaker/src/charm.py
+++ b/charms/metallb-speaker/src/charm.py
@@ -179,6 +179,9 @@ class MetalLBSpeakerCharm(CharmBase):
                     },
                 }],
                 'kubernetesResources': {
+                    'pod': {
+                        'hostNetwork': True
+                    },
                     'secrets': [{
                         'name': 'memberlist',
                         'type': 'Opaque',

--- a/docs/rbac-permissions-operators.yaml
+++ b/docs/rbac-permissions-operators.yaml
@@ -28,6 +28,14 @@ subjects:
   name: metallb-speaker-operator
   # change namespace name according to your environment
   namespace: metallb-system
+- kind: ServiceAccount
+  name: metallb-controller
+  # change namespace name according to your environment
+  namespace: metallb-system
+- kind: ServiceAccount
+  name: metallb-speaker
+  # change namespace name according to your environment
+  namespace: metallb-system
 roleRef:
   kind: ClusterRole
   name: use-k8s-api


### PR DESCRIPTION
When deploying the metallb operator, 4 service accounts are created: metallb-controller-operator, metallb-speaker-operator, metallb-controller, metallb-speaker. For the metallb-controller to function correctly, it also needs access to list configmaps. This error was seen in the logs when I tried with the previous configuration:

```
E0317 15:22:00.604453       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190620085101-78d2af792bab/tools/cache/reflector.go:98: Failed to list *v1.ConfigMap: configmaps "config" is forbidden: User "system:serviceaccount:metallb-system:metallb-controller" cannot list resource "configmaps" in API group "" in the namespace "metallb-system"
```

And the loadbalancer services would not be getting an external IP. This change in the permissions fixed it.