### PR TITLE
Add charmcraft.yaml

### DIFF
--- a/.github/workflows/metallb-workflow.yaml
+++ b/.github/workflows/metallb-workflow.yaml
@@ -76,9 +76,6 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-    # TODO: move to actions-operator?
-    - name: Alias microk8s.kubectl
-      run: sudo snap alias microk8s.kubectl kubectl
     # RBAC is enabled by default; TODO: ideally, this would be an option of actions-operator
     - name: Disable RBAC
       if: ${{ matrix.rbac == 'without RBAC' }}

--- a/bundle/tests/conftest.py
+++ b/bundle/tests/conftest.py
@@ -102,7 +102,7 @@ class TestHelpers:
         for subject in rbac_rules[1]["subjects"]:
             subject["namespace"] = self.ops_test.model_name
         rbac_dst_path.write_text(yaml.safe_dump_all(rbac_rules))
-        await self.kubectl("apply", "-f", rbac_dst_path)
+        await self.kubectl("apply", "-f", str(rbac_dst_path))
 
     async def deploy_microbot(self):
         await self.kubectl("apply", "-f", "./docs/example-microbot-lb.yaml")

--- a/charms/metallb-controller/charmcraft.yaml
+++ b/charms/metallb-controller/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"

--- a/charms/metallb-speaker/charmcraft.yaml
+++ b/charms/metallb-speaker/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"

--- a/docs/rbac-permissions-operators.yaml
+++ b/docs/rbac-permissions-operators.yaml
@@ -40,4 +40,3 @@ roleRef:
   kind: ClusterRole
   name: use-k8s-api
   apiGroup: rbac.authorization.k8s.io
----


### PR DESCRIPTION
Fixes build failures with Charmcraft 1.5.0. `charmcraft.yaml` is required now.