### PR TITLE
correct the run-on bases

### DIFF
--- a/charms/metallb-speaker/charmcraft.yaml
+++ b/charms/metallb-speaker/charmcraft.yaml
@@ -9,8 +9,6 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
-    - name: "ubuntu"
-      channel: "22.04"
       architectures:
         - amd64
         - arm


### PR DESCRIPTION
[LP#1992797](https://bugs.launchpad.net/snapstore-server/+bug/1992797) was created as a result of having the wrong intended bases in the charmcraft.yaml. 

careful notice shows that i accidentally defined 2 `channel: "22.04"` rather than 2 separate 22.04 and 20.04 channels