### PR TITLE
update container images from v0.9.3 to v0.12

### DIFF
--- a/bundle/tests/test_bundle.py
+++ b/bundle/tests/test_bundle.py
@@ -21,6 +21,7 @@ async def test_build_and_deploy(ops_test, test_helpers, rbac):
         controller_charm,
         config={"iprange": "10.1.240.240-10.1.240.241"},
         resources={"metallb-controller-image": "metallb/controller:v0.12"},
+        trust=True
     )
     speaker = await ops_test.model.deploy(
         speaker_charm,

--- a/bundle/tests/test_bundle.py
+++ b/bundle/tests/test_bundle.py
@@ -25,6 +25,7 @@ async def test_build_and_deploy(ops_test, test_helpers, rbac):
     speaker = await ops_test.model.deploy(
         speaker_charm,
         resources={"metallb-speaker-image": "metallb/speaker:v0.12"},
+        trust=True
     )
 
     if rbac:

--- a/bundle/tests/test_bundle.py
+++ b/bundle/tests/test_bundle.py
@@ -20,11 +20,11 @@ async def test_build_and_deploy(ops_test, test_helpers, rbac):
     controller = await ops_test.model.deploy(
         controller_charm,
         config={"iprange": "10.1.240.240-10.1.240.241"},
-        resources={"metallb-controller-image": "metallb/controller:v0.9.3"},
+        resources={"metallb-controller-image": "metallb/controller:v0.12"},
     )
     speaker = await ops_test.model.deploy(
         speaker_charm,
-        resources={"metallb-speaker-image": "metallb/speaker:v0.9.3"},
+        resources={"metallb-speaker-image": "metallb/speaker:v0.12"},
     )
 
     if rbac:

--- a/charms/metallb-controller/charmcraft.yaml
+++ b/charms/metallb-controller/charmcraft.yaml
@@ -1,5 +1,5 @@
 # Architectures based on supported arch's in upstream
-# https://hub.docker.com/layers/metallb/controller/v0.9.3/images/sha256-c8b0da00dd83db99bf00fb7088c33e7aaf52fa679f962610f1fe5ed173f66b77
+# https://hub.docker.com/layers/metallb/controller/v0.12/images/sha256-2787f87563065ee3461b6e24691bcdafd09d2166a4691800b58136d7d1701b65
 type: charm
 bases:
   - build-on:

--- a/charms/metallb-controller/metadata.yaml
+++ b/charms/metallb-controller/metadata.yaml
@@ -22,4 +22,4 @@ resources:
   metallb-controller-image:
     type: oci-image
     description: upstream docker image for metallb-controller
-    upstream-source: 'metallb/controller:v0.9.3'
+    upstream-source: 'metallb/controller:v0.12'

--- a/charms/metallb-speaker/charmcraft.yaml
+++ b/charms/metallb-speaker/charmcraft.yaml
@@ -1,5 +1,5 @@
 # Architectures based on supported arch's in upstream
-# https://hub.docker.com/layers/metallb/speaker/v0.9.3/images/sha256-70952965b63b7463c6c0fccb82f2d4e24bc08ea847eb2c1b487c39e4d8a67229
+# https://hub.docker.com/layers/metallb/speaker/v0.12/images/sha256-a1dc3ae8d53b40490d0fb4b25026ec51d88ab2b27bb2b91602780f7eb58b699e
 type: charm
 bases:
   - build-on:

--- a/charms/metallb-speaker/metadata.yaml
+++ b/charms/metallb-speaker/metadata.yaml
@@ -21,4 +21,4 @@ resources:
   metallb-speaker-image:
     type: oci-image
     description: upstream docker image for metallb-controller
-    upstream-source: 'metallb/speaker:v0.9.3'
+    upstream-source: 'metallb/speaker:v0.12'

--- a/docs/local-overlay.yaml
+++ b/docs/local-overlay.yaml
@@ -10,8 +10,8 @@ applications:
   metallb-controller:
     charm: ../metallb-controller.charm
     resources:
-      metallb-controller-image: 'metallb/controller:v0.9.3'
+      metallb-controller-image: 'metallb/controller:v0.12'
   metallb-speaker:
     charm: ../metallb-speaker.charm
     resources:
-      metallb-speaker-image: 'metallb/speaker:v0.9.3'
+      metallb-speaker-image: 'metallb/speaker:v0.12'


### PR DESCRIPTION
Closes [LP#1994064](https://bugs.launchpad.net/operator-metallb/+bug/1994064) by updating metallb-controller/speaker container images to v0.12