### PR TITLE
switch upstream-source for the container image to pull from quay.io

### DIFF
--- a/charms/metallb-controller/metadata.yaml
+++ b/charms/metallb-controller/metadata.yaml
@@ -22,4 +22,4 @@ resources:
   metallb-controller-image:
     type: oci-image
     description: upstream docker image for metallb-controller
-    upstream-source: 'metallb/controller:v0.12'
+    upstream-source: 'quay.io/metallb/controller:v0.12'

--- a/charms/metallb-speaker/metadata.yaml
+++ b/charms/metallb-speaker/metadata.yaml
@@ -21,4 +21,4 @@ resources:
   metallb-speaker-image:
     type: oci-image
     description: upstream docker image for metallb-controller
-    upstream-source: 'metallb/speaker:v0.12'
+    upstream-source: 'quay.io/metallb/speaker:v0.12'


### PR DESCRIPTION
Have the charm pull from quay.io when building locally

* https://github.com/kubernetes/minikube/issues/16053