### PR TITLE
Adjust github actions to run tests with modern tox, juju, and microk8s

### DIFF
--- a/bundle/tests/test_bundle.py
+++ b/bundle/tests/test_bundle.py
@@ -20,12 +20,12 @@ async def test_build_and_deploy(ops_test, test_helpers, rbac):
     controller = await ops_test.model.deploy(
         controller_charm,
         config={"iprange": "10.1.240.240-10.1.240.241"},
-        resources={"metallb-controller-image": "metallb/controller:v0.12"},
+        resources={"metallb-controller-image": "quay.io/metallb/controller:v0.12"},
         trust=True
     )
     speaker = await ops_test.model.deploy(
         speaker_charm,
-        resources={"metallb-speaker-image": "metallb/speaker:v0.12"},
+        resources={"metallb-speaker-image": "quay.io/metallb/speaker:v0.12"},
         trust=True
     )
 

--- a/charms/metallb-controller/tox.ini
+++ b/charms/metallb-controller/tox.ini
@@ -48,7 +48,8 @@ deps =
 
 [flake8]
 ignore =
-    W504 # line break after binary operator
+    # line break after binary operator
+    W504,
 exclude =
     .git,
     __pycache__,

--- a/charms/metallb-speaker/tox.ini
+++ b/charms/metallb-speaker/tox.ini
@@ -48,7 +48,8 @@ deps =
 
 [flake8]
 ignore =
-    W504 # line break after binary operator
+    # line break after binary operator
+    W504,
 exclude =
     .git,
     __pycache__,

--- a/tox.ini
+++ b/tox.ini
@@ -33,16 +33,3 @@ deps =
     ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s bundle/tests {posargs}
 
-[flake8]
-ignore =
-    W504 # line break after binary operator
-exclude =
-    .git,
-    __pycache__,
-    .tox,
-    mod,
-    .history,
-    build,
-    .build,
-max-line-length = 88
-max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     pytest
     pytest-operator
     aiohttp
+    juju < 3.1
     ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s bundle/tests {posargs}
 


### PR DESCRIPTION
* fix new [flake8 version](https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30) which caused lint failures on this repo
* Using versions of juju<3.1 until can convert from pod_spec charms
* Use images pulled from quay.io

