### PR TITLE
LP#2030108 - Add L2 Advertisements deployed via the charm

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -29,7 +29,7 @@ jobs:
         rbac: [ "without RBAC", "with RBAC" ]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/src/charm.py
+++ b/src/charm.py
@@ -84,8 +84,10 @@ class MetallbCharm(ops.CharmBase):
         self.native_manifest = MetallbNativeManifest(self, self.config)
         self.native_collector = Collector(self.native_manifest)
         self.client = Client(namespace=self.model.name, field_manager=self.app.name)
-        self.pool_name = f"{self.model.name}-{self.app.name}"
+        self.l2_adv_name = self.pool_name = f"{self.model.name}-{self.app.name}"
+
         # Create generic lightkube resource class for the MetalLB IPAddressPool
+        # Create generic lightkube resource class for the MetalLB L2Advertisement
         # https://metallb.universe.tf/configuration/
         self.IPAddressPool = create_namespaced_resource(
             group="metallb.io",
@@ -94,11 +96,33 @@ class MetallbCharm(ops.CharmBase):
             plural="ipaddresspools",
         )
 
+        self.L2Advertisement = create_namespaced_resource(
+            group="metallb.io",
+            version="v1beta1",
+            kind="L2Advertisement",
+            plural="l2advertisements",
+        )
+
         self.framework.observe(self.on.install, self._install_or_upgrade)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.upgrade_charm, self._install_or_upgrade)
         self.framework.observe(self.on.update_status, self._update_status)
         self.framework.observe(self.on.remove, self._cleanup)
+
+    def _confirm_resource(self, resource, name) -> bool:
+        try:
+            self.client.get(resource, name=name, namespace=self.config["namespace"])
+        except ApiError as e:
+            if "not found" in e.status.message:
+                logger.info(f"{resource.__name__} not found yet")
+                self.unit.status = WaitingStatus(f"Waiting for {resource.__name__} to be created")
+                return False
+            else:
+                # surface any other errors besides not found
+                logger.exception(e)
+                self.unit.status = WaitingStatus("Waiting for Kubernetes API")
+                return False
+        return True
 
     def _update_status(self, _):
         missing = _missing_resources(self.native_manifest)
@@ -115,20 +139,11 @@ class MetallbCharm(ops.CharmBase):
             self.unit.status = WaitingStatus(", ".join(native_unready))
             return
 
-        try:
-            self.client.get(
-                self.IPAddressPool, name=self.pool_name, namespace=self.config["namespace"]
-            )
-        except ApiError as e:
-            if "not found" in e.status.message:
-                logger.info("IPAddressPool not found yet")
-                self.unit.status = WaitingStatus("Waiting for IPAddressPool to be created")
-                return
-            else:
-                # surface any other errors besides not found
-                logger.exception(e)
-                self.unit.status = WaitingStatus("Waiting for Kubernetes API")
-                return
+        if not self._confirm_resource(self.IPAddressPool, self.pool_name):
+            return
+        if not self._confirm_resource(self.L2Advertisement, self.l2_adv_name):
+            return
+
         self.unit.status = ActiveStatus("Ready")
         self.unit.set_workload_version(self.native_collector.short_version)
         self.app.status = ActiveStatus(self.native_collector.long_version)
@@ -156,13 +171,14 @@ class MetallbCharm(ops.CharmBase):
 
         addresses = stripped.split(",")
         self._update_ip_pool(addresses)
+        self._update_l2_adv()
         self.unit.status = ActiveStatus()
 
     # retrying is necessary as the ip address pool webhooks take some time to come up
     @retry(
         retry=retry_if_exception_type(ApiError),
         reraise=True,
-        before=before_log(logger, logging.INFO),
+        before=before_log(logger, logging.DEBUG),
         wait=wait_exponential(multiplier=1, min=2, max=60 * 2),
     )
     def _update_ip_pool(self, addresses):
@@ -172,6 +188,14 @@ class MetallbCharm(ops.CharmBase):
         )
 
         self.client.apply(ip_pool, force=True)
+
+    def _update_l2_adv(self):
+        l2_adv = self.L2Advertisement(
+            metadata={"name": self.l2_adv_name, "namespace": self.config["namespace"]},
+            spec={"ipAddressPools": [self.pool_name]},
+        )
+
+        self.client.apply(l2_adv, force=True)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/data/microbot.yaml
+++ b/tests/data/microbot.yaml
@@ -24,7 +24,7 @@ spec:
         app: microbot-lb
     spec:
       containers:
-      - image: dontrebootme/microbot:v1
+      - image: rocks.canonical.com:443/cdk/cdkbot/microbot-amd64:latest
         imagePullPolicy: ""
         name: microbot-lb
         ports:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,20 @@ from lightkube.resources.core_v1 import Service
 logger = logging.getLogger(__name__)
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--iprange",
+        action="store",
+        default="10.1.240.240-10.1.240.241",
+        help="Juju controller to use",
+    )
+
+
+@pytest.fixture
+def iprange(request):
+    return request.config.getoption("--iprange")
+
+
 @pytest.fixture(scope="module")
 def client():
     return Client()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     )
 
 
-async def test_iprange_config_option(ops_test: OpsTest, client, ip_address_pool):
+async def test_iprange_config_option(ops_test: OpsTest, client, ip_address_pool, iprange):
     # test that default option is applied correctly before changing
     pool_name = f"{ops_test.model_name}-{APP_NAME}"
     pool = client.get(ip_address_pool, name=pool_name, namespace=NAMESPACE)
@@ -47,12 +47,12 @@ async def test_iprange_config_option(ops_test: OpsTest, client, ip_address_pool)
     logger.info("Updating iprange ...")
     await app.set_config(
         {
-            "iprange": "10.1.240.240-10.1.240.241",
+            "iprange": iprange,
         }
     )
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
     pool = client.get(ip_address_pool, name=pool_name, namespace=NAMESPACE)
-    assert pool.spec["addresses"][0] == "10.1.240.240-10.1.240.241"
+    assert pool.spec["addresses"][0] == iprange
 
 
 async def test_loadbalancer_service(ops_test: OpsTest, client, microbot_service_ip):


### PR DESCRIPTION
In order to provide an out-of-the-box L2 deployement, the charm should ensure L2Advertisments are deployed in the cluster

https://metallb.universe.tf/configuration/#layer-2-configuration

Updating the charm to ensure that occurs


Addresses [LP#2030108](https://bugs.launchpad.net/operator-metallb/+bug/2030108)