### PR TITLE
Address LP#2033710 by improving the IP address parsing

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.10']"
     needs:
       - call-inclusive-naming-check
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@ type: charm
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
       architectures: ["amd64"]
     run-on:
     - name: "ubuntu"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -92,7 +92,7 @@ def test_config_change_updates_ip_pool(harness, lk_charm_client):
     assert call_obj["spec"]["addresses"][0] == "192.168.1.240-192.168.1.247"
     assert call_obj["spec"]["addresses"][1] == "10.1.240.240-10.1.240.241"
     assert call_obj["spec"]["addresses"][2] == "192.168.10.0/24"
-    assert call_obj["spec"]["addresses"][3] == "fc00:f853:0ccd:e799::/124"
+    assert call_obj["spec"]["addresses"][3] == "fc00:f853:ccd:e799::/124"
 
     # test with multiple ranges with spaces thrown in
     lk_charm_client.reset_mock()
@@ -108,7 +108,7 @@ def test_config_change_updates_ip_pool(harness, lk_charm_client):
     assert call_obj["spec"]["addresses"][0] == "192.168.1.240-192.168.1.247"
     assert call_obj["spec"]["addresses"][1] == "10.1.240.240-10.1.240.241"
     assert call_obj["spec"]["addresses"][2] == "192.168.10.0/24"
-    assert call_obj["spec"]["addresses"][3] == "fc00:f853:0ccd:e799::/124"
+    assert call_obj["spec"]["addresses"][3] == "fc00:f853:ccd:e799::/124"
 
     # test with an empty range
     lk_charm_client.reset_mock()


### PR DESCRIPTION
[LP#2033710](https://bugs.launchpad.net/operator-metallb/+bug/2033710)

When one configs the charm with a single ip address such as `iprange=192.168.0.1` rather than `iprange=192.168.0.1/32` -- the charm fails to deal with this config and attempts to set the bare address in the `spec.addresses` of `metallb.io/v1beta1/IPaddressPool`

this causes an API error 403 forbidden because values of `spec.addresses` must either be an address range or a cidr subnet, not a single value

A worse situation is the charm cannot recover because it retries forever rather than stopping with an eventual error.