### PR TITLE
[LP#2068597] Metallb deployments can get stuck in a config-changed busy loop

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -50,12 +50,11 @@ def _is_ip_address_range(str_to_test):
     return True
 
 
-def _is_cidr(str_to_test):
-    if str_to_test.count("/") != 1:
-        return False
+def _is_cidr(str_to_test: str) -> bool:
     try:
         ipaddress.ip_network(str_to_test)
-        return True
+        # prevent strings which don't end in '/<subnet>'
+        return not _is_ip_address(str_to_test)
     except ValueError:
         return False
 
@@ -81,7 +80,7 @@ def _block_on_forbidden(unit: ops.model.Unit):
     except (ApiError, ManifestClientError) as ex:
         http = ex.args[1] if isinstance(ex, ManifestClientError) else ex
         if http.status.code == 403:
-            unit.status = BlockedStatus("API Access Forbidden, deploy with --trust")
+            unit.status = BlockedStatus("API Access Forbidden, deploy with --trust?")
         else:
             raise
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,6 +51,8 @@ def _is_ip_address_range(str_to_test):
 
 
 def _is_cidr(str_to_test):
+    if str_to_test.count("/") != 1:
+        return False
     try:
         ipaddress.ip_network(str_to_test)
         return True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -168,9 +168,9 @@ def test_update_status(harness, lk_manifests_client, lk_charm_client):
     harness.begin()
 
     # With nothing mocked, all resources will appear as missing
+    harness.charm.model.unit.status = expected = BlockedStatus("unchanged on missing")
     harness.charm.on.update_status.emit()
-    assert "missing" in harness.charm.model.unit.status.message
-    assert harness.charm.model.unit.status.name == "blocked"
+    assert harness.charm.model.unit.status == expected
 
     # mock to get past missing resources code path
     with mock.patch("charm._missing_resources", autospec=True) as mock_missing:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -138,6 +138,13 @@ def test_config_change_updates_ip_pool(harness, lk_charm_client):
         "Invalid iprange: 256.256.256.256/24 is not a valid CIDR or ip range"
     )
 
+    # test with an invalid Address
+    lk_charm_client.reset_mock()
+    harness.update_config({"iprange": "192.168.1.2"})
+    assert harness.charm.model.unit.status == BlockedStatus(
+        "Invalid iprange: 192.168.1.2 is not a valid CIDR or ip range"
+    )
+
 
 def test_remove_deletes_manifest_objects(harness, lk_manifests_client):
     # Test that the remove-handler deletes the objects specified in the manifest

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,6 +175,7 @@ def test_update_status(harness, lk_manifests_client, lk_charm_client):
     harness.begin()
 
     # With nothing mocked, all resources will appear as missing
+    harness.charm._stored.configured = True
     harness.charm.model.unit.status = expected = BlockedStatus("unchanged on missing")
     harness.charm.on.update_status.emit()
     assert harness.charm.model.unit.status == expected

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -138,7 +138,7 @@ def test_config_change_updates_ip_pool(harness, lk_charm_client):
         "Invalid iprange: 256.256.256.256/24 is not a valid CIDR or ip range"
     )
 
-    # test with an invalid Address
+    # test with an address without the cidr range is invalid
     lk_charm_client.reset_mock()
     harness.update_config({"iprange": "192.168.1.2"})
     assert harness.charm.model.unit.status == BlockedStatus(
@@ -176,7 +176,7 @@ def test_update_status(harness, lk_manifests_client, lk_charm_client):
 
     # With nothing mocked, all resources will appear as missing
     harness.charm._stored.configured = True
-    harness.charm.model.unit.status = expected = BlockedStatus("unchanged on missing")
+    harness.charm.model.unit.status = expected = BlockedStatus("TeSt BlOcKeD MeSsAgE")
     harness.charm.on.update_status.emit()
     assert harness.charm.model.unit.status == expected
 


### PR DESCRIPTION
[LP#2068597](https://bugs.launchpad.net/operator-metallb/+bug/2068597)

# Overview
When metallb doesn't have permissions because of lack of `trust`, the charm can get stuck trying to apply a configuration that will never finish causing the config-change hook to perpetually run. 

# Changes
* use tenacity `stop` to quick retrying after a certain number of times
* use a context_manager to block the charm when 403 error codes are returned from the API indicating a lack of permission
* Don't let the update_status hook wipe out the `blocked` status
* Only go to ActiveStatus when the `update_status` handler declares everything is ready
* Use MaintenanceStatus to indicate the charm is working on something
* Include tests to confirm the charm is blocked when not deployed with `trust`