### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ first installed. This namespace will be created by the charm and should not exis
 It defaults to `metallb-system`, as this is the upstream default. 
 
 The `image-registry` config option sets the image registry used for any MetalLB pods. It defaults to 
-`rocks.canonical.com:443/cdk`. Note that this charm is workload-less, so there are no OCI-image resources associated with
+`ghcr.io/canonical/cdk`. Note that this charm is workload-less, so there are no OCI-image resources associated with
 it, as the charm simply applies a manifest via the Kubernetes API. You will need to use a registry that contains 
 the speaker and controller images required by the upstream manifest. 
 

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
       Image registry for metallb container images.
       The value set here will replace the host portion of each image URL in
       the release manifests.
-    default: "rocks.canonical.com:443/cdk"
+    default: "ghcr.io/canonical/cdk"
 
   metallb-release:
     type: string

--- a/tests/data/microbot.yaml
+++ b/tests/data/microbot.yaml
@@ -24,7 +24,7 @@ spec:
         app: microbot-lb
     spec:
       containers:
-      - image: rocks.canonical.com:443/cdk/cdkbot/microbot-amd64:latest
+      - image: ghcr.io/canonical/cdk/cdkbot/microbot-amd64:latest
         imagePullPolicy: ""
         name: microbot-lb
         ports:


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
